### PR TITLE
Add .dependencyLicenses file for license checks

### DIFF
--- a/.dependencyLicenses
+++ b/.dependencyLicenses
@@ -1,0 +1,1 @@
+./input/content/assets/js/heading-links.js


### PR DESCRIPTION
Introduce a `.dependencyLicenses` file to exclude specific files from license checks, improving compliance management.

